### PR TITLE
feat: expand Dune API coverage (16 new endpoints)

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -5,7 +5,8 @@
 use crate::error::{DuneError, DuneRequestError};
 use crate::parameters::Parameter;
 use crate::response::{
-    CancellationResponse, ExecutionResponse, ExecutionStatus, GetResultResponse, GetStatusResponse,
+    CancellationResponse, DuneQuery, ExecutionResponse, ExecutionStatus, GetResultResponse,
+    GetStatusResponse, QueryBody, QueryResponse,
 };
 use dotenvy::dotenv;
 use log::{debug, error, info, warn};
@@ -91,6 +92,23 @@ impl DuneClient {
         let client = reqwest::Client::new();
         client
             .post(&request_url)
+            .header("x-dune-api-key", &self.api_key)
+            .json(&body)
+            .send()
+            .await
+    }
+
+    /// Internal PATCH request handler with JSON body
+    async fn _patch(
+        &self,
+        route: &str,
+        body: serde_json::Value,
+    ) -> Result<Response, Error> {
+        let request_url = format!("{BASE_URL}/{route}");
+        debug!("PATCH to {} with body {:?}", route, &body);
+        let client = reqwest::Client::new();
+        client
+            .patch(&request_url)
             .header("x-dune-api-key", &self.api_key)
             .json(&body)
             .send()
@@ -279,6 +297,96 @@ impl DuneClient {
             .await
             .map_err(DuneRequestError::from)?;
         DuneClient::_parse_text_response(response).await
+    }
+
+    /// Create a new Dune query.
+    ///
+    /// `body.name` and `body.query_sql` are required by the API.
+    pub async fn create_query(
+        &self,
+        body: QueryBody,
+    ) -> Result<QueryResponse, DuneRequestError> {
+        let response = self
+            ._post_json("query", serde_json::to_value(&body).unwrap())
+            .await
+            .map_err(DuneRequestError::from)?;
+        DuneClient::_parse_response::<QueryResponse>(response).await
+    }
+
+    /// Read a query's metadata and SQL by ID.
+    pub async fn get_query(
+        &self,
+        query_id: u32,
+    ) -> Result<DuneQuery, DuneRequestError> {
+        let response = self
+            ._get_url(&format!("query/{query_id}"))
+            .await
+            .map_err(DuneRequestError::from)?;
+        DuneClient::_parse_response::<DuneQuery>(response).await
+    }
+
+    /// Update a query's SQL, name, description, tags, or privacy.
+    pub async fn update_query(
+        &self,
+        query_id: u32,
+        body: QueryBody,
+    ) -> Result<QueryResponse, DuneRequestError> {
+        let response = self
+            ._patch(
+                &format!("query/{query_id}"),
+                serde_json::to_value(&body).unwrap(),
+            )
+            .await
+            .map_err(DuneRequestError::from)?;
+        DuneClient::_parse_response::<QueryResponse>(response).await
+    }
+
+    /// Archive a query (prevents running or editing).
+    pub async fn archive_query(
+        &self,
+        query_id: u32,
+    ) -> Result<QueryResponse, DuneRequestError> {
+        let response = self
+            ._post_json(&format!("query/{query_id}/archive"), json!({}))
+            .await
+            .map_err(DuneRequestError::from)?;
+        DuneClient::_parse_response::<QueryResponse>(response).await
+    }
+
+    /// Unarchive a previously archived query.
+    pub async fn unarchive_query(
+        &self,
+        query_id: u32,
+    ) -> Result<QueryResponse, DuneRequestError> {
+        let response = self
+            ._post_json(&format!("query/{query_id}/unarchive"), json!({}))
+            .await
+            .map_err(DuneRequestError::from)?;
+        DuneClient::_parse_response::<QueryResponse>(response).await
+    }
+
+    /// Make a query private (owner-only access).
+    pub async fn make_query_private(
+        &self,
+        query_id: u32,
+    ) -> Result<QueryResponse, DuneRequestError> {
+        let response = self
+            ._post_json(&format!("query/{query_id}/private"), json!({}))
+            .await
+            .map_err(DuneRequestError::from)?;
+        DuneClient::_parse_response::<QueryResponse>(response).await
+    }
+
+    /// Make a private query public.
+    pub async fn make_query_public(
+        &self,
+        query_id: u32,
+    ) -> Result<QueryResponse, DuneRequestError> {
+        let response = self
+            ._post_json(&format!("query/{query_id}/unprivate"), json!({}))
+            .await
+            .map_err(DuneRequestError::from)?;
+        DuneClient::_parse_response::<QueryResponse>(response).await
     }
 
     /// Convenience method for users to
@@ -473,6 +581,66 @@ mod tests {
             },
             results.get_rows()[0]
         )
+    }
+
+    #[tokio::test]
+    async fn query_crud_lifecycle() {
+        use crate::response::{QueryBody, QueryResponse};
+
+        let dune = DuneClient::from_env();
+
+        // Create
+        let created = dune
+            .create_query(QueryBody {
+                name: Some("duners test query".to_string()),
+                query_sql: Some("SELECT 1 AS n".to_string()),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        let qid = created.query_id;
+        assert!(qid > 0);
+
+        // Read
+        let query = dune.get_query(qid).await.unwrap();
+        assert_eq!(query.name, "duners test query");
+        assert_eq!(query.query_sql, "SELECT 1 AS n");
+
+        // Update
+        let updated = dune
+            .update_query(
+                qid,
+                QueryBody {
+                    name: Some("duners test query updated".to_string()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(updated.query_id, qid);
+
+        // Make private
+        dune.make_query_private(qid).await.unwrap();
+        let query = dune.get_query(qid).await.unwrap();
+        assert!(query.is_private);
+
+        // Make public
+        dune.make_query_public(qid).await.unwrap();
+        let query = dune.get_query(qid).await.unwrap();
+        assert!(!query.is_private);
+
+        // Archive
+        dune.archive_query(qid).await.unwrap();
+        let query = dune.get_query(qid).await.unwrap();
+        assert!(query.is_archived);
+
+        // Unarchive
+        dune.unarchive_query(qid).await.unwrap();
+        let query = dune.get_query(qid).await.unwrap();
+        assert!(!query.is_archived);
+
+        // Clean up: archive again
+        dune.archive_query(qid).await.unwrap();
     }
 
     #[tokio::test]

--- a/src/client.rs
+++ b/src/client.rs
@@ -83,11 +83,7 @@ impl DuneClient {
     }
 
     /// Internal POST request handler with arbitrary JSON body
-    async fn _post_json(
-        &self,
-        route: &str,
-        body: serde_json::Value,
-    ) -> Result<Response, Error> {
+    async fn _post_json(&self, route: &str, body: serde_json::Value) -> Result<Response, Error> {
         let request_url = format!("{BASE_URL}/{route}");
         debug!("POST to {} with body {:?}", route, &body);
         let client = reqwest::Client::new();
@@ -100,11 +96,7 @@ impl DuneClient {
     }
 
     /// Internal PATCH request handler with JSON body
-    async fn _patch(
-        &self,
-        route: &str,
-        body: serde_json::Value,
-    ) -> Result<Response, Error> {
+    async fn _patch(&self, route: &str, body: serde_json::Value) -> Result<Response, Error> {
         let request_url = format!("{BASE_URL}/{route}");
         debug!("PATCH to {} with body {:?}", route, &body);
         let client = reqwest::Client::new();
@@ -224,6 +216,18 @@ impl DuneClient {
     ///
     /// The `performance` parameter controls the execution tier:
     /// `"medium"` (default), `"large"`, or `"community"`.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use duners::{DuneClient, DuneRequestError};
+    ///
+    /// # async fn run() -> Result<(), DuneRequestError> {
+    /// let client = DuneClient::from_env();
+    /// let exec = client.execute_sql("SELECT 1 AS n", None).await?;
+    /// println!("Execution ID: {}", exec.execution_id);
+    /// # Ok(()) }
+    /// ```
     pub async fn execute_sql(
         &self,
         sql: &str,
@@ -296,6 +300,22 @@ impl DuneClient {
     ///
     /// Returns the most recent execution results for the given query ID.
     /// Does not consume credits (no re-execution).
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use duners::{DuneClient, DuneRequestError};
+    /// use serde::Deserialize;
+    ///
+    /// #[derive(Deserialize, Debug)]
+    /// struct Row { symbol: String, price: f64 }
+    ///
+    /// # async fn run() -> Result<(), DuneRequestError> {
+    /// let client = DuneClient::from_env();
+    /// let results = client.get_latest_results::<Row>(971694).await?;
+    /// for row in results.get_rows() { println!("{:?}", row); }
+    /// # Ok(()) }
+    /// ```
     pub async fn get_latest_results<T: DeserializeOwned>(
         &self,
         query_id: u32,
@@ -308,10 +328,7 @@ impl DuneClient {
     }
 
     /// Get the latest results for a query as CSV text.
-    pub async fn get_latest_results_csv(
-        &self,
-        query_id: u32,
-    ) -> Result<String, DuneRequestError> {
+    pub async fn get_latest_results_csv(&self, query_id: u32) -> Result<String, DuneRequestError> {
         let response = self
             ._get_url(&format!("query/{query_id}/results/csv"))
             .await
@@ -320,10 +337,7 @@ impl DuneClient {
     }
 
     /// Get execution results as CSV text (by `job_id`).
-    pub async fn get_results_csv(
-        &self,
-        job_id: &str,
-    ) -> Result<String, DuneRequestError> {
+    pub async fn get_results_csv(&self, job_id: &str) -> Result<String, DuneRequestError> {
         let response = self
             ._get_url(&format!("execution/{job_id}/results/csv"))
             .await
@@ -334,10 +348,23 @@ impl DuneClient {
     /// Create a new Dune query.
     ///
     /// `body.name` and `body.query_sql` are required by the API.
-    pub async fn create_query(
-        &self,
-        body: QueryBody,
-    ) -> Result<QueryResponse, DuneRequestError> {
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use duners::{DuneClient, DuneRequestError, QueryBody};
+    ///
+    /// # async fn run() -> Result<(), DuneRequestError> {
+    /// let client = DuneClient::from_env();
+    /// let resp = client.create_query(QueryBody {
+    ///     name: Some("My query".into()),
+    ///     query_sql: Some("SELECT 1 AS n".into()),
+    ///     ..Default::default()
+    /// }).await?;
+    /// println!("Query ID: {}", resp.query_id);
+    /// # Ok(()) }
+    /// ```
+    pub async fn create_query(&self, body: QueryBody) -> Result<QueryResponse, DuneRequestError> {
         let response = self
             ._post_json("query", serde_json::to_value(&body).unwrap())
             .await
@@ -346,10 +373,7 @@ impl DuneClient {
     }
 
     /// Read a query's metadata and SQL by ID.
-    pub async fn get_query(
-        &self,
-        query_id: u32,
-    ) -> Result<DuneQuery, DuneRequestError> {
+    pub async fn get_query(&self, query_id: u32) -> Result<DuneQuery, DuneRequestError> {
         let response = self
             ._get_url(&format!("query/{query_id}"))
             .await
@@ -374,10 +398,7 @@ impl DuneClient {
     }
 
     /// Archive a query (prevents running or editing).
-    pub async fn archive_query(
-        &self,
-        query_id: u32,
-    ) -> Result<QueryResponse, DuneRequestError> {
+    pub async fn archive_query(&self, query_id: u32) -> Result<QueryResponse, DuneRequestError> {
         let response = self
             ._post_json(&format!("query/{query_id}/archive"), json!({}))
             .await
@@ -386,10 +407,7 @@ impl DuneClient {
     }
 
     /// Unarchive a previously archived query.
-    pub async fn unarchive_query(
-        &self,
-        query_id: u32,
-    ) -> Result<QueryResponse, DuneRequestError> {
+    pub async fn unarchive_query(&self, query_id: u32) -> Result<QueryResponse, DuneRequestError> {
         let response = self
             ._post_json(&format!("query/{query_id}/unarchive"), json!({}))
             .await
@@ -434,6 +452,23 @@ impl DuneClient {
     }
 
     /// Upload CSV data to create or replace a table.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use duners::{DuneClient, DuneRequestError, UploadCsvRequest};
+    ///
+    /// # async fn run() -> Result<(), DuneRequestError> {
+    /// let client = DuneClient::from_env();
+    /// let resp = client.upload_csv(UploadCsvRequest {
+    ///     data: "name,age\nAlice,30\nBob,25".into(),
+    ///     table_name: "my_table".into(),
+    ///     description: None,
+    ///     is_private: Some(true),
+    /// }).await?;
+    /// println!("Table: {}", resp.full_name);
+    /// # Ok(()) }
+    /// ```
     pub async fn upload_csv(
         &self,
         request: UploadCsvRequest,
@@ -703,8 +738,16 @@ mod tests {
                 namespace: namespace.clone(),
                 table_name: table_name.to_string(),
                 schema: vec![
-                    ColumnDef { name: "name".to_string(), column_type: "varchar".to_string(), nullable: None },
-                    ColumnDef { name: "age".to_string(), column_type: "integer".to_string(), nullable: None },
+                    ColumnDef {
+                        name: "name".to_string(),
+                        column_type: "varchar".to_string(),
+                        nullable: None,
+                    },
+                    ColumnDef {
+                        name: "age".to_string(),
+                        column_type: "integer".to_string(),
+                        nullable: None,
+                    },
                 ],
                 description: None,
                 is_private: Some(true),
@@ -821,10 +864,7 @@ mod tests {
     #[tokio::test]
     async fn execute_sql() {
         let dune = DuneClient::from_env();
-        let exec = dune
-            .execute_sql("SELECT 1 AS n", None)
-            .await
-            .unwrap();
+        let exec = dune.execute_sql("SELECT 1 AS n", None).await.unwrap();
         assert!(!exec.execution_id.is_empty());
         let cancellation = dune.cancel_execution(&exec.execution_id).await.unwrap();
         assert!(cancellation.success);
@@ -834,20 +874,13 @@ mod tests {
     async fn get_latest_results() {
         let dune = DuneClient::from_env();
 
-        #[derive(Deserialize, Debug)]
-        struct ExpectedResults {
-            token: String,
-            symbol: String,
-            max_price: f64,
-        }
-
         let results = dune
-            .get_latest_results::<ExpectedResults>(QUERY_ID)
+            .get_latest_results::<HashMap<String, serde_json::Value>>(QUERY_ID)
             .await
             .unwrap();
         let rows = results.result.rows;
         assert_eq!(1, rows.len());
-        assert_eq!(rows[0].symbol, "WETH");
+        assert_eq!(rows[0]["symbol"], "WETH");
     }
 
     #[tokio::test]

--- a/src/client.rs
+++ b/src/client.rs
@@ -5,8 +5,9 @@
 use crate::error::{DuneError, DuneRequestError};
 use crate::parameters::Parameter;
 use crate::response::{
-    CancellationResponse, DuneQuery, ExecutionResponse, ExecutionStatus, GetResultResponse,
-    GetStatusResponse, QueryBody, QueryResponse,
+    CancellationResponse, CreateTableRequest, CreateTableResponse, DuneQuery, ExecutionResponse,
+    ExecutionStatus, GetResultResponse, GetStatusResponse, InsertTableResponse, QueryBody,
+    QueryResponse, SuccessResponse, UploadCsvRequest,
 };
 use dotenvy::dotenv;
 use log::{debug, error, info, warn};
@@ -146,6 +147,37 @@ impl DuneClient {
             error!("request error {:?}", &err);
             Err(DuneRequestError::from(err))
         }
+    }
+
+    /// Internal DELETE request handler
+    async fn _delete(&self, route: &str) -> Result<Response, Error> {
+        let request_url = format!("{BASE_URL}/{route}");
+        debug!("DELETE {}", &request_url);
+        let client = reqwest::Client::new();
+        client
+            .delete(&request_url)
+            .header("x-dune-api-key", &self.api_key)
+            .send()
+            .await
+    }
+
+    /// Internal POST request handler with raw body and custom content type
+    async fn _post_raw(
+        &self,
+        route: &str,
+        content_type: &str,
+        body: String,
+    ) -> Result<Response, Error> {
+        let request_url = format!("{BASE_URL}/{route}");
+        debug!("POST raw to {} ({} bytes)", route, body.len());
+        let client = reqwest::Client::new();
+        client
+            .post(&request_url)
+            .header("x-dune-api-key", &self.api_key)
+            .header("content-type", content_type)
+            .body(body)
+            .send()
+            .await
     }
 
     /// Parses response body as text (for CSV endpoints).
@@ -389,6 +421,80 @@ impl DuneClient {
         DuneClient::_parse_response::<QueryResponse>(response).await
     }
 
+    /// Create an empty table with an explicit schema.
+    pub async fn create_table(
+        &self,
+        request: CreateTableRequest,
+    ) -> Result<CreateTableResponse, DuneRequestError> {
+        let response = self
+            ._post_json("uploads", serde_json::to_value(&request).unwrap())
+            .await
+            .map_err(DuneRequestError::from)?;
+        DuneClient::_parse_response::<CreateTableResponse>(response).await
+    }
+
+    /// Upload CSV data to create or replace a table.
+    pub async fn upload_csv(
+        &self,
+        request: UploadCsvRequest,
+    ) -> Result<CreateTableResponse, DuneRequestError> {
+        let response = self
+            ._post_json("uploads/csv", serde_json::to_value(&request).unwrap())
+            .await
+            .map_err(DuneRequestError::from)?;
+        DuneClient::_parse_response::<CreateTableResponse>(response).await
+    }
+
+    /// Insert rows into an existing table.
+    ///
+    /// `content_type` should be `"text/csv"` or `"application/x-ndjson"`.
+    pub async fn insert_table_rows(
+        &self,
+        namespace: &str,
+        table_name: &str,
+        content_type: &str,
+        data: String,
+    ) -> Result<InsertTableResponse, DuneRequestError> {
+        let response = self
+            ._post_raw(
+                &format!("uploads/{namespace}/{table_name}/insert"),
+                content_type,
+                data,
+            )
+            .await
+            .map_err(DuneRequestError::from)?;
+        DuneClient::_parse_response::<InsertTableResponse>(response).await
+    }
+
+    /// Remove all data from a table (preserves schema).
+    pub async fn clear_table(
+        &self,
+        namespace: &str,
+        table_name: &str,
+    ) -> Result<SuccessResponse, DuneRequestError> {
+        let response = self
+            ._post_json(
+                &format!("uploads/{namespace}/{table_name}/clear"),
+                json!({}),
+            )
+            .await
+            .map_err(DuneRequestError::from)?;
+        DuneClient::_parse_response::<SuccessResponse>(response).await
+    }
+
+    /// Permanently delete a table and all its data.
+    pub async fn delete_table(
+        &self,
+        namespace: &str,
+        table_name: &str,
+    ) -> Result<SuccessResponse, DuneRequestError> {
+        let response = self
+            ._delete(&format!("uploads/{namespace}/{table_name}"))
+            .await
+            .map_err(DuneRequestError::from)?;
+        DuneClient::_parse_response::<SuccessResponse>(response).await
+    }
+
     /// Convenience method for users to
     /// 1. execute,
     /// 2. wait for execution to complete,
@@ -584,8 +690,77 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn table_lifecycle() {
+        use crate::response::{ColumnDef, CreateTableRequest};
+
+        let dune = DuneClient::from_env();
+        let namespace = env::var("DUNE_NAMESPACE").unwrap_or_else(|_| "bh2smith".to_string());
+        let table_name = "duners_test_table";
+
+        // Create table with schema
+        let created = dune
+            .create_table(CreateTableRequest {
+                namespace: namespace.clone(),
+                table_name: table_name.to_string(),
+                schema: vec![
+                    ColumnDef { name: "name".to_string(), column_type: "varchar".to_string(), nullable: None },
+                    ColumnDef { name: "age".to_string(), column_type: "integer".to_string(), nullable: None },
+                ],
+                description: None,
+                is_private: Some(true),
+            })
+            .await
+            .unwrap();
+        assert!(!created.full_name.is_empty());
+
+        // Insert rows via CSV
+        let inserted = dune
+            .insert_table_rows(
+                &namespace,
+                table_name,
+                "text/csv",
+                "name,age\nAlice,30\nBob,25".to_string(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(inserted.rows_written, 2);
+
+        // Clear table
+        let cleared = dune.clear_table(&namespace, table_name).await.unwrap();
+        assert!(cleared.message.is_some());
+
+        // Delete table
+        let deleted = dune.delete_table(&namespace, table_name).await.unwrap();
+        assert!(deleted.message.is_some());
+    }
+
+    #[tokio::test]
+    async fn upload_csv_lifecycle() {
+        use crate::response::UploadCsvRequest;
+
+        let dune = DuneClient::from_env();
+        let namespace = env::var("DUNE_NAMESPACE").unwrap_or_else(|_| "bh2smith".to_string());
+
+        // Upload CSV (creates the table)
+        let upload = dune
+            .upload_csv(UploadCsvRequest {
+                data: "name,age\nAlice,30\nBob,25".to_string(),
+                table_name: "duners_csv_test".to_string(),
+                description: None,
+                is_private: Some(true),
+            })
+            .await
+            .unwrap();
+        assert!(!upload.full_name.is_empty());
+
+        // Clean up
+        let actual_table = upload.table_name.as_deref().unwrap_or("duners_csv_test");
+        dune.delete_table(&namespace, actual_table).await.unwrap();
+    }
+
+    #[tokio::test]
     async fn query_crud_lifecycle() {
-        use crate::response::{QueryBody, QueryResponse};
+        use crate::response::QueryBody;
 
         let dune = DuneClient::from_env();
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -80,6 +80,23 @@ impl DuneClient {
             .await
     }
 
+    /// Internal POST request handler with arbitrary JSON body
+    async fn _post_json(
+        &self,
+        route: &str,
+        body: serde_json::Value,
+    ) -> Result<Response, Error> {
+        let request_url = format!("{BASE_URL}/{route}");
+        debug!("POST to {} with body {:?}", route, &body);
+        let client = reqwest::Client::new();
+        client
+            .post(&request_url)
+            .header("x-dune-api-key", &self.api_key)
+            .json(&body)
+            .send()
+            .await
+    }
+
     /// Internal GET request handler for arbitrary routes
     async fn _get_url(&self, route: &str) -> Result<Response, Error> {
         let request_url = format!("{BASE_URL}/{route}");
@@ -148,6 +165,26 @@ impl DuneClient {
     ) -> Result<ExecutionResponse, DuneRequestError> {
         let response = self
             ._post(&format!("query/{query_id}/execute"), params)
+            .await
+            .map_err(DuneRequestError::from)?;
+        DuneClient::_parse_response::<ExecutionResponse>(response).await
+    }
+
+    /// Execute raw SQL directly without a saved query.
+    ///
+    /// The `performance` parameter controls the execution tier:
+    /// `"medium"` (default), `"large"`, or `"community"`.
+    pub async fn execute_sql(
+        &self,
+        sql: &str,
+        performance: Option<&str>,
+    ) -> Result<ExecutionResponse, DuneRequestError> {
+        let mut body = json!({ "sql": sql });
+        if let Some(perf) = performance {
+            body["performance"] = json!(perf);
+        }
+        let response = self
+            ._post_json("sql/execute", body)
             .await
             .map_err(DuneRequestError::from)?;
         DuneClient::_parse_response::<ExecutionResponse>(response).await
@@ -436,6 +473,18 @@ mod tests {
             },
             results.get_rows()[0]
         )
+    }
+
+    #[tokio::test]
+    async fn execute_sql() {
+        let dune = DuneClient::from_env();
+        let exec = dune
+            .execute_sql("SELECT 1 AS n", None)
+            .await
+            .unwrap();
+        assert!(!exec.execution_id.is_empty());
+        let cancellation = dune.cancel_execution(&exec.execution_id).await.unwrap();
+        assert!(cancellation.success);
     }
 
     #[tokio::test]

--- a/src/client.rs
+++ b/src/client.rs
@@ -80,9 +80,9 @@ impl DuneClient {
             .await
     }
 
-    /// Internal GET request handler
-    async fn _get(&self, job_id: &str, command: &str) -> Result<Response, Error> {
-        let request_url = format!("{BASE_URL}/execution/{job_id}/{command}");
+    /// Internal GET request handler for arbitrary routes
+    async fn _get_url(&self, route: &str) -> Result<Response, Error> {
+        let request_url = format!("{BASE_URL}/{route}");
         debug!("GET from {}", &request_url);
         let client = reqwest::Client::new();
         client
@@ -92,11 +92,31 @@ impl DuneClient {
             .await
     }
 
+    /// Internal GET request handler for execution endpoints
+    async fn _get(&self, job_id: &str, command: &str) -> Result<Response, Error> {
+        self._get_url(&format!("execution/{job_id}/{command}"))
+            .await
+    }
+
     /// Deserializes Responses into appropriate type.
     /// Some "invalid" requests return response JSON, which are parsed and returned as Errors.
     async fn _parse_response<T: DeserializeOwned>(resp: Response) -> Result<T, DuneRequestError> {
         if resp.status().is_success() {
             resp.json::<T>().await.map_err(DuneRequestError::from)
+        } else {
+            let err = resp
+                .json::<DuneError>()
+                .await
+                .map_err(DuneRequestError::from)?;
+            error!("request error {:?}", &err);
+            Err(DuneRequestError::from(err))
+        }
+    }
+
+    /// Parses response body as text (for CSV endpoints).
+    async fn _parse_text_response(resp: Response) -> Result<String, DuneRequestError> {
+        if resp.status().is_success() {
+            resp.text().await.map_err(DuneRequestError::from)
         } else {
             let err = resp
                 .json::<DuneError>()
@@ -183,6 +203,45 @@ impl DuneClient {
             .await
             .map_err(DuneRequestError::from)?;
         DuneClient::_parse_response::<GetResultResponse<T>>(response).await
+    }
+
+    /// Get the latest results for a query without triggering a new execution.
+    ///
+    /// Returns the most recent execution results for the given query ID.
+    /// Does not consume credits (no re-execution).
+    pub async fn get_latest_results<T: DeserializeOwned>(
+        &self,
+        query_id: u32,
+    ) -> Result<GetResultResponse<T>, DuneRequestError> {
+        let response = self
+            ._get_url(&format!("query/{query_id}/results"))
+            .await
+            .map_err(DuneRequestError::from)?;
+        DuneClient::_parse_response::<GetResultResponse<T>>(response).await
+    }
+
+    /// Get the latest results for a query as CSV text.
+    pub async fn get_latest_results_csv(
+        &self,
+        query_id: u32,
+    ) -> Result<String, DuneRequestError> {
+        let response = self
+            ._get_url(&format!("query/{query_id}/results/csv"))
+            .await
+            .map_err(DuneRequestError::from)?;
+        DuneClient::_parse_text_response(response).await
+    }
+
+    /// Get execution results as CSV text (by `job_id`).
+    pub async fn get_results_csv(
+        &self,
+        job_id: &str,
+    ) -> Result<String, DuneRequestError> {
+        let response = self
+            ._get_url(&format!("execution/{job_id}/results/csv"))
+            .await
+            .map_err(DuneRequestError::from)?;
+        DuneClient::_parse_text_response(response).await
     }
 
     /// Convenience method for users to
@@ -377,6 +436,42 @@ mod tests {
             },
             results.get_rows()[0]
         )
+    }
+
+    #[tokio::test]
+    async fn get_latest_results() {
+        let dune = DuneClient::from_env();
+
+        #[derive(Deserialize, Debug)]
+        struct ExpectedResults {
+            token: String,
+            symbol: String,
+            max_price: f64,
+        }
+
+        let results = dune
+            .get_latest_results::<ExpectedResults>(QUERY_ID)
+            .await
+            .unwrap();
+        let rows = results.result.rows;
+        assert_eq!(1, rows.len());
+        assert_eq!(rows[0].symbol, "WETH");
+    }
+
+    #[tokio::test]
+    async fn get_latest_results_csv() {
+        let dune = DuneClient::from_env();
+        let csv = dune.get_latest_results_csv(QUERY_ID).await.unwrap();
+        assert!(csv.contains("token"));
+        assert!(csv.contains("WETH"));
+    }
+
+    #[tokio::test]
+    async fn get_results_csv() {
+        let dune = DuneClient::from_env();
+        let csv = dune.get_results_csv(JOB_ID).await.unwrap();
+        assert!(csv.contains("token"));
+        assert!(csv.contains("WETH"));
     }
 
     #[tokio::test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,4 +52,8 @@ pub mod response;
 pub use client::DuneClient;
 pub use error::DuneRequestError;
 pub use parameters::Parameter;
-pub use response::{DuneQuery, ExecutionStatus, GetResultResponse, QueryBody, QueryResponse};
+pub use response::{
+    ColumnDef, CreateTableRequest, CreateTableResponse, DuneQuery, ExecutionStatus,
+    GetResultResponse, InsertTableResponse, QueryBody, QueryResponse, SuccessResponse,
+    UploadCsvRequest,
+};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,4 +52,4 @@ pub mod response;
 pub use client::DuneClient;
 pub use error::DuneRequestError;
 pub use parameters::Parameter;
-pub use response::{ExecutionStatus, GetResultResponse};
+pub use response::{DuneQuery, ExecutionStatus, GetResultResponse, QueryBody, QueryResponse};

--- a/src/response.rs
+++ b/src/response.rs
@@ -6,7 +6,7 @@
 
 use crate::parse_utils::{datetime_from_str, optional_datetime_from_str};
 use chrono::{DateTime, Utc};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use serde_with::DeserializeFromStr;
 use std::str::FromStr;
 
@@ -209,6 +209,50 @@ impl<T> GetResultResponse<T> {
     pub fn get_rows(self) -> Vec<T> {
         self.result.rows
     }
+}
+
+/// Response from query create, update, archive, unarchive, private, and unprivate endpoints.
+#[derive(Deserialize, Debug)]
+pub struct QueryResponse {
+    pub query_id: u32,
+}
+
+/// Full query object returned by `GET /v1/query/{queryId}`.
+#[derive(Deserialize, Debug)]
+pub struct DuneQuery {
+    pub query_id: u32,
+    pub name: String,
+    #[serde(default)]
+    pub description: Option<String>,
+    pub query_sql: String,
+    pub is_private: bool,
+    pub is_archived: bool,
+    #[serde(default)]
+    pub query_engine: Option<String>,
+    #[serde(default)]
+    pub version: Option<u32>,
+    #[serde(default)]
+    pub tags: Option<Vec<String>>,
+    #[serde(default)]
+    pub parameters: Option<Vec<serde_json::Value>>,
+}
+
+/// Request body for creating or updating a query.
+///
+/// For `create_query`, `name` and `query_sql` are required by the API.
+/// For `update_query`, all fields are optional.
+#[derive(Serialize, Debug, Default)]
+pub struct QueryBody {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub query_sql: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub is_private: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tags: Option<Vec<String>>,
 }
 
 #[cfg(test)]

--- a/src/response.rs
+++ b/src/response.rs
@@ -255,6 +255,74 @@ pub struct QueryBody {
     pub tags: Option<Vec<String>>,
 }
 
+/// Column definition for creating a table.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ColumnDef {
+    pub name: String,
+    #[serde(rename = "type")]
+    pub column_type: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub nullable: Option<bool>,
+}
+
+/// Request body for `POST /v1/uploads` (create empty table with schema).
+#[derive(Serialize, Debug)]
+pub struct CreateTableRequest {
+    pub namespace: String,
+    pub table_name: String,
+    pub schema: Vec<ColumnDef>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub is_private: Option<bool>,
+}
+
+/// Response from `POST /v1/uploads` and `POST /v1/uploads/csv`.
+#[derive(Deserialize, Debug)]
+pub struct CreateTableResponse {
+    #[serde(default)]
+    pub success: Option<bool>,
+    #[serde(default)]
+    pub namespace: Option<String>,
+    #[serde(default)]
+    pub table_name: Option<String>,
+    #[serde(default)]
+    pub full_name: String,
+    #[serde(default)]
+    pub example_query: Option<String>,
+    #[serde(default)]
+    pub already_existed: Option<bool>,
+    #[serde(default)]
+    pub message: Option<String>,
+}
+
+/// Request body for `POST /v1/uploads/csv`.
+#[derive(Serialize, Debug)]
+pub struct UploadCsvRequest {
+    pub data: String,
+    pub table_name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub is_private: Option<bool>,
+}
+
+/// Response from `POST /v1/uploads/{namespace}/{table_name}/insert`.
+#[derive(Deserialize, Debug)]
+pub struct InsertTableResponse {
+    pub rows_written: u64,
+    pub bytes_written: u64,
+    #[serde(default)]
+    pub name: Option<String>,
+}
+
+/// Generic success response with a message field (used by clear and delete table).
+#[derive(Deserialize, Debug)]
+pub struct SuccessResponse {
+    #[serde(default)]
+    pub message: Option<String>,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/response.rs
+++ b/src/response.rs
@@ -212,67 +212,164 @@ impl<T> GetResultResponse<T> {
 }
 
 /// Response from query create, update, archive, unarchive, private, and unprivate endpoints.
+///
+/// # Example
+///
+/// ```no_run
+/// use duners::{DuneClient, DuneRequestError, QueryBody};
+///
+/// # async fn run() -> Result<(), DuneRequestError> {
+/// let client = DuneClient::from_env();
+/// let resp = client.create_query(QueryBody {
+///     name: Some("My query".into()),
+///     query_sql: Some("SELECT 1".into()),
+///     ..Default::default()
+/// }).await?;
+/// println!("Created query {}", resp.query_id);
+/// # Ok(()) }
+/// ```
 #[derive(Deserialize, Debug)]
 pub struct QueryResponse {
+    /// The Dune query ID.
     pub query_id: u32,
 }
 
 /// Full query object returned by `GET /v1/query/{queryId}`.
+///
+/// # Example
+///
+/// ```no_run
+/// use duners::{DuneClient, DuneRequestError};
+///
+/// # async fn run() -> Result<(), DuneRequestError> {
+/// let client = DuneClient::from_env();
+/// let query = client.get_query(971694).await?;
+/// println!("{}: {}", query.name, query.query_sql);
+/// # Ok(()) }
+/// ```
 #[derive(Deserialize, Debug)]
 pub struct DuneQuery {
+    /// The Dune query ID.
     pub query_id: u32,
+    /// Human-readable query name.
     pub name: String,
+    /// Optional description of the query.
     #[serde(default)]
     pub description: Option<String>,
+    /// The SQL text of the query.
     pub query_sql: String,
+    /// Whether the query is private (owner-only).
     pub is_private: bool,
+    /// Whether the query is archived.
     pub is_archived: bool,
+    /// SQL engine used (e.g. `"medium"`).
     #[serde(default)]
     pub query_engine: Option<String>,
+    /// Query version number.
     #[serde(default)]
     pub version: Option<u32>,
+    /// User-defined tags.
     #[serde(default)]
     pub tags: Option<Vec<String>>,
+    /// Query parameters defined in the Dune editor.
     #[serde(default)]
     pub parameters: Option<Vec<serde_json::Value>>,
 }
 
 /// Request body for creating or updating a query.
 ///
-/// For `create_query`, `name` and `query_sql` are required by the API.
-/// For `update_query`, all fields are optional.
+/// For [`create_query`](crate::client::DuneClient::create_query), `name` and `query_sql` are required by the API.
+/// For [`update_query`](crate::client::DuneClient::update_query), all fields are optional.
+///
+/// # Example
+///
+/// ```rust
+/// use duners::QueryBody;
+///
+/// let body = QueryBody {
+///     name: Some("My query".into()),
+///     query_sql: Some("SELECT 1 AS n".into()),
+///     ..Default::default()
+/// };
+/// ```
 #[derive(Serialize, Debug, Default)]
 pub struct QueryBody {
+    /// Query name (required for create).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
+    /// SQL text (required for create).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub query_sql: Option<String>,
+    /// Optional description.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
+    /// Whether the query should be private.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub is_private: Option<bool>,
+    /// User-defined tags.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tags: Option<Vec<String>>,
 }
 
 /// Column definition for creating a table.
+///
+/// # Example
+///
+/// ```rust
+/// use duners::ColumnDef;
+///
+/// let col = ColumnDef {
+///     name: "price".into(),
+///     column_type: "double".into(),
+///     nullable: Some(true),
+/// };
+/// ```
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ColumnDef {
+    /// Column name.
     pub name: String,
+    /// Dune column type (e.g. `"varchar"`, `"integer"`, `"double"`, `"boolean"`).
     #[serde(rename = "type")]
     pub column_type: String,
+    /// Whether the column accepts NULL values.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub nullable: Option<bool>,
 }
 
 /// Request body for `POST /v1/uploads` (create empty table with schema).
+///
+/// # Example
+///
+/// ```no_run
+/// use duners::{DuneClient, DuneRequestError, CreateTableRequest, ColumnDef};
+///
+/// # async fn run() -> Result<(), DuneRequestError> {
+/// let client = DuneClient::from_env();
+/// let resp = client.create_table(CreateTableRequest {
+///     namespace: "my_team".into(),
+///     table_name: "prices".into(),
+///     schema: vec![
+///         ColumnDef { name: "symbol".into(), column_type: "varchar".into(), nullable: None },
+///         ColumnDef { name: "price".into(), column_type: "double".into(), nullable: None },
+///     ],
+///     description: None,
+///     is_private: Some(true),
+/// }).await?;
+/// println!("Created: {}", resp.full_name);
+/// # Ok(()) }
+/// ```
 #[derive(Serialize, Debug)]
 pub struct CreateTableRequest {
+    /// Dune namespace (usually your username or team name).
     pub namespace: String,
+    /// Table name.
     pub table_name: String,
+    /// Column definitions.
     pub schema: Vec<ColumnDef>,
+    /// Optional table description.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
+    /// Whether the table should be private.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub is_private: Option<bool>,
 }
@@ -280,18 +377,25 @@ pub struct CreateTableRequest {
 /// Response from `POST /v1/uploads` and `POST /v1/uploads/csv`.
 #[derive(Deserialize, Debug)]
 pub struct CreateTableResponse {
+    /// Whether the operation succeeded (present for CSV uploads).
     #[serde(default)]
     pub success: Option<bool>,
+    /// Dune namespace.
     #[serde(default)]
     pub namespace: Option<String>,
+    /// Table name (may include a `dataset_` prefix for CSV uploads).
     #[serde(default)]
     pub table_name: Option<String>,
+    /// Fully qualified table name (e.g. `dune.my_team.my_table`).
     #[serde(default)]
     pub full_name: String,
+    /// Example SQL query to read from this table.
     #[serde(default)]
     pub example_query: Option<String>,
+    /// Whether the table already existed before this call.
     #[serde(default)]
     pub already_existed: Option<bool>,
+    /// Additional message from the API.
     #[serde(default)]
     pub message: Option<String>,
 }
@@ -299,10 +403,14 @@ pub struct CreateTableResponse {
 /// Request body for `POST /v1/uploads/csv`.
 #[derive(Serialize, Debug)]
 pub struct UploadCsvRequest {
+    /// CSV content as a string (including header row).
     pub data: String,
+    /// Table name to create or replace.
     pub table_name: String,
+    /// Optional table description.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
+    /// Whether the table should be private.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub is_private: Option<bool>,
 }
@@ -310,8 +418,11 @@ pub struct UploadCsvRequest {
 /// Response from `POST /v1/uploads/{namespace}/{table_name}/insert`.
 #[derive(Deserialize, Debug)]
 pub struct InsertTableResponse {
+    /// Number of rows written.
     pub rows_written: u64,
+    /// Total bytes written.
     pub bytes_written: u64,
+    /// Table name.
     #[serde(default)]
     pub name: Option<String>,
 }
@@ -319,6 +430,7 @@ pub struct InsertTableResponse {
 /// Generic success response with a message field (used by clear and delete table).
 #[derive(Deserialize, Debug)]
 pub struct SuccessResponse {
+    /// Human-readable message from the API.
     #[serde(default)]
     pub message: Option<String>,
 }


### PR DESCRIPTION
## Summary

Brings duners from 4/34 to 20/34 Dune API endpoint coverage across 4 commits:

- **Latest results + CSV formats** (3 endpoints): `get_latest_results`, `get_latest_results_csv`, `get_results_csv` — fetch results without re-execution and in CSV format
- **Execute raw SQL** (1 endpoint): `execute_sql` — run SQL directly without a saved query via `POST /v1/sql/execute`
- **Query CRUD** (7 endpoints): `create_query`, `get_query`, `update_query`, `archive_query`, `unarchive_query`, `make_query_private`, `make_query_public`
- **Table uploads** (5 endpoints): `create_table`, `upload_csv`, `insert_table_rows`, `clear_table`, `delete_table` — full table lifecycle via `/v1/uploads` API

Also adds internal HTTP helpers: `_post_json`, `_get_url`, `_patch`, `_delete`, `_post_raw`, `_parse_text_response`.

## Test plan

- [x] All 38 tests pass (up from 25)
- [x] Query CRUD lifecycle test: create → read → update → private → public → archive → unarchive
- [x] Table lifecycle test: create with schema → insert CSV rows → clear → delete
- [x] CSV upload lifecycle test: upload CSV → delete
- [x] Execute SQL test: execute → cancel
- [x] Latest results tests: JSON + CSV for both query-level and execution-level