### PR TITLE
fix: make doc-coverage nightly pin effective

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -34,8 +34,9 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Install Rust nightly
-        # Pinned nightly: rustdoc --show-coverage (doc coverage) is nightly-only;
-        # pin a known-good nightly for reproducible CI.
+        # doc-coverage uses `rustdoc --show-coverage`, which is nightly-only
+        # (rust-lang/rust#58154). SHA-pin the action to master and select a
+        # dated, known-good nightly so CI stays reproducible.
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: nightly-2026-06-01
@@ -50,3 +51,6 @@ jobs:
 
       - name: Doc coverage check
         run: bash scripts/check-doc-coverage.sh
+        env:
+          # Use the pinned nightly installed above (must match toolchain: input).
+          NIGHTLY_TOOLCHAIN: nightly-2026-06-01

--- a/scripts/check-doc-coverage.sh
+++ b/scripts/check-doc-coverage.sh
@@ -26,10 +26,13 @@ if [[ -n "${DOC_COVERAGE_OUTPUT:-}" ]]; then
   echo "Using existing coverage output: $DOC_COVERAGE_OUTPUT"
   COVERAGE_OUTPUT="$DOC_COVERAGE_OUTPUT"
 else
-  echo "Running rustdoc coverage (nightly)..."
+  # CI pins a known-good nightly via NIGHTLY_TOOLCHAIN for reproducibility;
+  # defaults to the floating nightly channel for local use.
+  NIGHTLY_TOOLCHAIN="${NIGHTLY_TOOLCHAIN:-nightly}"
+  echo "Running rustdoc coverage (+${NIGHTLY_TOOLCHAIN})..."
   COVERAGE_OUTPUT=$(mktemp)
   trap 'rm -f "$COVERAGE_OUTPUT"' EXIT
-  cargo +nightly rustdoc -Z unstable-options -- -Z unstable-options --show-coverage 2>&1 | tee "$COVERAGE_OUTPUT"
+  cargo "+${NIGHTLY_TOOLCHAIN}" rustdoc -Z unstable-options -- -Z unstable-options --show-coverage 2>&1 | tee "$COVERAGE_OUTPUT"
 fi
 
 TOTAL_LINE=$(grep '| Total ' "$COVERAGE_OUTPUT" || true)


### PR DESCRIPTION
The doc-coverage CI pin was ineffective: scripts/check-doc-coverage.sh used floating `cargo +nightly`, so rustup installed the latest nightly regardless of the pinned toolchain. This wires a NIGHTLY_TOOLCHAIN override (nightly-2026-06-01) so CI uses a reproducible nightly. doc-coverage is nightly-only (rust-lang/rust#58154).

Towards PLA-2114

Made with [Cursor](https://cursor.com)