### PR TITLE
fix(parse_utils): accept number-or-string numerics and broaden timestamp parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,26 +91,29 @@ Parameter names must match the names defined in the query on Dune.
 
 ## Deserializing result rows
 
-Define a struct whose fields match the query’s columns and derive `Deserialize`. You can use your own types; the API often returns numbers and dates as **strings**, so use the helpers in [`parse_utils`](https://docs.rs/duners/latest/duners/parse_utils/index.html) when needed:
+Define a struct whose fields match the query’s columns and derive `Deserialize`. You can use your own types; depending on the column type, the API returns numbers and dates either as JSON numbers or as **strings**, so use the helpers in [`parse_utils`](https://docs.rs/duners/latest/duners/parse_utils/index.html) to accept both:
 
 ```rust
 use chrono::{DateTime, Utc};
-use duners::parse_utils::{datetime_from_str, f64_from_str};
+use duners::parse_utils::{datetime_from_str, f64_from_str, optional_datetime_from_str, u64_from_str};
 use serde::Deserialize;
 
 #[derive(Deserialize, Debug)]
 struct ResultStruct {
     text_field: String,
     #[serde(deserialize_with = "f64_from_str")]
-    number_field: f64,
+    volume_usd: f64,
+    #[serde(deserialize_with = "u64_from_str")]
+    trade_count: u64,
     #[serde(deserialize_with = "datetime_from_str")]
-    date_field: DateTime<Utc>,
-    list_field: String,
+    block_time: DateTime<Utc>,
+    #[serde(default, deserialize_with = "optional_datetime_from_str")]
+    first_trade_at: Option<DateTime<Utc>>,
 }
 ```
 
-- **`f64_from_str`** — for numeric columns that come as strings.
-- **`datetime_from_str`** — for date/timestamp columns that come as strings.
+- **`f64_from_str`** / **`u64_from_str`** — for numeric columns, whether they arrive as JSON numbers or strings (Dune encodes e.g. decimals and bigints as strings).
+- **`datetime_from_str`** / **`optional_datetime_from_str`** — for date/timestamp columns; accepts RFC 3339 as well as Dune result formats like `2022-01-01 01:02:03[.000][ UTC]`.
 
 ## Lower-level API
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -972,8 +972,11 @@ mod tests {
     #[tokio::test]
     async fn invalid_query_id() {
         let dune = DuneClient::from_env();
-        let error = dune.execute_query(u32::MAX, None).await.unwrap_err();
-        assert!(matches!(error, DuneRequestError::Dune(_)))
+        let error = dune.execute_query(i32::MAX as u32, None).await.unwrap_err();
+        assert_eq!(
+            error,
+            DuneRequestError::Dune(String::from("Query not found"))
+        )
     }
 
     #[tokio::test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@
 //! - **[`stream_query`](client::DuneClient::stream_query) / [`stream_sql`](client::DuneClient::stream_sql)** — Paged variants that yield each result page as it is fetched, for large result sets.
 //! - **Lower-level API** — [`execute_query`](client::DuneClient::execute_query), [`get_status`](client::DuneClient::get_status), [`get_results`](client::DuneClient::get_results), [`cancel_execution`](client::DuneClient::cancel_execution) for full control.
 //! - **[`Parameter`](parameters::Parameter)** — Query parameters (text, number, date, list) for parameterized queries.
-//! - **[`parse_utils`](parse_utils)** — Helpers for deserializing Dune’s JSON (e.g. dates and numbers that come as strings): [`datetime_from_str`](parse_utils::datetime_from_str), [`f64_from_str`](parse_utils::f64_from_str).
+//! - **[`parse_utils`](parse_utils)** — Helpers for deserializing Dune’s JSON (dates and numbers that arrive as JSON numbers or strings): [`datetime_from_str`](parse_utils::datetime_from_str), [`f64_from_str`](parse_utils::f64_from_str), [`u64_from_str`](parse_utils::u64_from_str).
 //! - **[`DuneRequestError`](error::DuneRequestError)** — All request and parsing errors.
 //!
 //! See the [README](https://github.com/bh2smith/duners) for more examples and details.

--- a/src/parse_utils.rs
+++ b/src/parse_utils.rs
@@ -1,7 +1,8 @@
 //! Utilities for parsing Dune API response fields.
 //!
-//! Dune often returns numbers and dates as **strings** in JSON. Use the deserializer helpers here
-//! with `#[serde(deserialize_with = "...")]` so your structs can use `f64` or `DateTime<Utc>`.
+//! Depending on the column type, Dune returns numbers and dates either as JSON numbers or as
+//! **strings**. Use the deserializer helpers here with `#[serde(deserialize_with = "...")]` so
+//! your structs can use `f64`, `u64`, or `DateTime<Utc>` regardless of the wire representation.
 
 use chrono::{DateTime, NaiveDateTime, ParseError, Utc};
 use serde::{de, Deserialize, Deserializer};
@@ -30,16 +31,25 @@ pub fn date_parse(date_str: &str) -> Result<DateTime<Utc>, ParseError> {
 
 /// Parses timestamp strings returned in **query result** columns (Dune timestamp type).
 ///
-/// Accepts `YYYY-MM-DD HH:MM:SS` or `YYYY-MM-DD HH:MM:SS.ffffff`.
+/// Accepts `YYYY-MM-DD HH:MM:SS` or `YYYY-MM-DD HH:MM:SS.ffffff`, with an optional ` UTC` suffix.
 pub fn dune_date(date_str: &str) -> Result<DateTime<Utc>, ParseError> {
+    let date_str = date_str.strip_suffix(" UTC").unwrap_or(date_str);
     // Try with microseconds first
     date_string_parser(date_str, "%Y-%m-%d %H:%M:%S.%f")
         .or_else(|_| date_string_parser(date_str, "%Y-%m-%d %H:%M:%S"))
 }
 
+fn parse_datetime(date_str: &str) -> Result<DateTime<Utc>, ParseError> {
+    if let Ok(parsed) = DateTime::parse_from_rfc3339(date_str) {
+        return Ok(parsed.with_timezone(&Utc));
+    }
+    date_parse(date_str).or_else(|_| dune_date(date_str))
+}
+
 /// Serde deserializer for date/time fields that Dune returns as strings.
 ///
-/// Tries API metadata format first, then query-result timestamp format. Use with
+/// Accepts RFC 3339 (with any offset), the API metadata format (`2022-01-01T12:00:00.000Z`), and
+/// query-result timestamps (`2022-01-01 12:00:00[.ffffff][ UTC]`). Use with
 /// `#[serde(deserialize_with = "duners::parse_utils::datetime_from_str")]` on `DateTime<Utc>` fields.
 ///
 /// # Example
@@ -56,17 +66,12 @@ where
     D: Deserializer<'de>,
 {
     let s: String = Deserialize::deserialize(deserializer)?;
-    match date_parse(&s) {
-        // First try to parse response type date strings
-        Ok(parsed_date) => Ok(parsed_date),
-        Err(_) => {
-            // First attempt didn't work, try another format
-            dune_date(&s).map_err(de::Error::custom)
-        }
-    }
+    parse_datetime(&s).map_err(de::Error::custom)
 }
 
 /// Serde deserializer for optional date/time strings (e.g. `expires_at`).
+///
+/// Accepts the same formats as [`datetime_from_str`]; `null` and missing values become `None`.
 pub fn optional_datetime_from_str<'de, D>(
     deserializer: D,
 ) -> Result<Option<DateTime<Utc>>, D::Error>
@@ -74,19 +79,15 @@ where
     D: Deserializer<'de>,
 {
     let s: Option<String> = Deserialize::deserialize(deserializer)?;
-    match s {
-        None => Ok(None),
-        Some(s) => {
-            let date = date_parse(&s).map_err(de::Error::custom)?;
-            Ok(Some(date))
-        }
-    }
+    s.map(|s| parse_datetime(&s).map_err(de::Error::custom))
+        .transpose()
 }
 
-/// Serde deserializer for numeric fields that Dune returns as strings.
+/// Serde deserializer for numeric fields that Dune returns as a JSON number **or** a string.
 ///
-/// Use with `#[serde(deserialize_with = "duners::parse_utils::f64_from_str")]` on `f64` fields
-/// when the API returns a string like `"3.14"` instead of a number.
+/// Dune encodes some numeric column types (e.g. decimals) as strings like `"1.25"` and others as
+/// plain JSON numbers. Use with `#[serde(deserialize_with = "duners::parse_utils::f64_from_str")]`
+/// on `f64` fields to accept both.
 ///
 /// # Example
 ///
@@ -100,17 +101,62 @@ where
 ///     price: f64,
 /// }
 ///
-/// // In real usage, MyRow is deserialized from Dune API JSON.
+/// let row: MyRow = serde_json::from_str(r#"{"price": "1.25"}"#).unwrap();
+/// assert_eq!(row.price, 1.25);
+/// let row: MyRow = serde_json::from_str(r#"{"price": 1.25}"#).unwrap();
+/// assert_eq!(row.price, 1.25);
 /// ```
 pub fn f64_from_str<'de, D>(deserializer: D) -> Result<f64, D::Error>
 where
     D: Deserializer<'de>,
 {
-    let value: Value = Deserialize::deserialize(deserializer)?;
-    if let Value::String(s) = value {
-        s.parse().map_err(de::Error::custom)
-    } else {
-        Err(de::Error::custom("Expected a string"))
+    match Value::deserialize(deserializer)? {
+        Value::Number(n) => n
+            .as_f64()
+            .ok_or_else(|| de::Error::custom("number does not fit in f64")),
+        Value::String(s) => s.parse().map_err(de::Error::custom),
+        other => Err(de::Error::custom(format!(
+            "expected a number or string, got {other}"
+        ))),
+    }
+}
+
+/// Serde deserializer for unsigned integer fields that Dune returns as a JSON number **or** a
+/// string.
+///
+/// Dune encodes `bigint`/`uint256` columns as strings like `"12345"` when they may exceed the
+/// JSON number range. Use with `#[serde(deserialize_with = "duners::parse_utils::u64_from_str")]`
+/// on `u64` fields to accept both.
+///
+/// # Example
+///
+/// ```rust
+/// use duners::parse_utils::u64_from_str;
+/// use serde::Deserialize;
+///
+/// #[derive(Deserialize)]
+/// struct MyRow {
+///     #[serde(deserialize_with = "u64_from_str")]
+///     trade_count: u64,
+/// }
+///
+/// let row: MyRow = serde_json::from_str(r#"{"trade_count": "42"}"#).unwrap();
+/// assert_eq!(row.trade_count, 42);
+/// let row: MyRow = serde_json::from_str(r#"{"trade_count": 42}"#).unwrap();
+/// assert_eq!(row.trade_count, 42);
+/// ```
+pub fn u64_from_str<'de, D>(deserializer: D) -> Result<u64, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    match Value::deserialize(deserializer)? {
+        Value::Number(n) => n
+            .as_u64()
+            .ok_or_else(|| de::Error::custom("number is not an unsigned integer")),
+        Value::String(s) => s.parse().map_err(de::Error::custom),
+        other => Err(de::Error::custom(format!(
+            "expected a number or string, got {other}"
+        ))),
     }
 }
 
@@ -143,5 +189,67 @@ mod tests {
             dune_date(date_str).unwrap().to_string(),
             "2022-05-04 00:00:00 UTC"
         )
+    }
+
+    #[test]
+    fn dune_date_with_utc_suffix() {
+        let date_str = "2022-05-04 00:00:00.000 UTC";
+        assert_eq!(
+            dune_date(date_str).unwrap().to_string(),
+            "2022-05-04 00:00:00 UTC"
+        )
+    }
+
+    #[test]
+    fn parse_datetime_accepts_all_formats() {
+        for date_str in [
+            "2022-01-01T01:02:03+00:00",
+            "2022-01-01T02:02:03+01:00",
+            "2022-01-01T01:02:03Z",
+            "2022-01-01T01:02:03.000Z",
+            "2022-01-01 01:02:03",
+            "2022-01-01 01:02:03.000",
+            "2022-01-01 01:02:03 UTC",
+        ] {
+            assert_eq!(
+                parse_datetime(date_str).unwrap().to_string(),
+                "2022-01-01 01:02:03 UTC",
+                "failed for {date_str}"
+            );
+        }
+    }
+
+    #[derive(Deserialize)]
+    struct NumberRow {
+        #[serde(deserialize_with = "f64_from_str")]
+        float: f64,
+        #[serde(deserialize_with = "u64_from_str")]
+        int: u64,
+        #[serde(default, deserialize_with = "optional_datetime_from_str")]
+        date: Option<DateTime<Utc>>,
+    }
+
+    #[test]
+    fn numbers_from_string_or_number() {
+        let row: NumberRow =
+            serde_json::from_str(r#"{"float": "1.25", "int": "42", "date": null}"#).unwrap();
+        assert_eq!(row.float, 1.25);
+        assert_eq!(row.int, 42);
+        assert_eq!(row.date, None);
+
+        let row: NumberRow =
+            serde_json::from_str(r#"{"float": 1.25, "int": 42, "date": "2022-01-01 01:02:03"}"#)
+                .unwrap();
+        assert_eq!(row.float, 1.25);
+        assert_eq!(row.int, 42);
+        assert_eq!(row.date.unwrap().to_string(), "2022-01-01 01:02:03 UTC");
+    }
+
+    #[test]
+    fn numbers_reject_invalid_values() {
+        assert!(serde_json::from_str::<NumberRow>(r#"{"float": true, "int": 1}"#).is_err());
+        assert!(serde_json::from_str::<NumberRow>(r#"{"float": 1.0, "int": -1}"#).is_err());
+        assert!(serde_json::from_str::<NumberRow>(r#"{"float": 1.0, "int": 1.5}"#).is_err());
+        assert!(serde_json::from_str::<NumberRow>(r#"{"float": "abc", "int": 1}"#).is_err());
     }
 }

--- a/src/parse_utils.rs
+++ b/src/parse_utils.rs
@@ -26,7 +26,7 @@ fn date_string_parser(date_str: &str, format: &str) -> Result<DateTime<Utc>, Par
 /// assert_eq!(dt.format("%Y-%m-%d").to_string(), "2022-01-01");
 /// ```
 pub fn date_parse(date_str: &str) -> Result<DateTime<Utc>, ParseError> {
-    date_string_parser(date_str, "%Y-%m-%dT%H:%M:%S.%fZ")
+    date_string_parser(date_str, "%Y-%m-%dT%H:%M:%S%.fZ")
 }
 
 /// Parses timestamp strings returned in **query result** columns (Dune timestamp type).
@@ -34,9 +34,8 @@ pub fn date_parse(date_str: &str) -> Result<DateTime<Utc>, ParseError> {
 /// Accepts `YYYY-MM-DD HH:MM:SS` or `YYYY-MM-DD HH:MM:SS.ffffff`, with an optional ` UTC` suffix.
 pub fn dune_date(date_str: &str) -> Result<DateTime<Utc>, ParseError> {
     let date_str = date_str.strip_suffix(" UTC").unwrap_or(date_str);
-    // Try with microseconds first
-    date_string_parser(date_str, "%Y-%m-%d %H:%M:%S.%f")
-        .or_else(|_| date_string_parser(date_str, "%Y-%m-%d %H:%M:%S"))
+    // `%.f` parses left-aligned fractional seconds (`.123` is 123ms, not 123ns) and is optional.
+    date_string_parser(date_str, "%Y-%m-%d %H:%M:%S%.f")
 }
 
 fn parse_datetime(date_str: &str) -> Result<DateTime<Utc>, ParseError> {
@@ -169,7 +168,7 @@ mod tests {
         let date_str = "2022-01-01T01:02:03.123Z";
         assert_eq!(
             date_parse(date_str).unwrap().to_string(),
-            "2022-01-01 01:02:03.000000123 UTC"
+            "2022-01-01 01:02:03.123 UTC"
         )
     }
 
@@ -189,6 +188,24 @@ mod tests {
             dune_date(date_str).unwrap().to_string(),
             "2022-05-04 00:00:00 UTC"
         )
+    }
+
+    #[test]
+    fn dune_date_with_subseconds() {
+        for (date_str, expected) in [
+            ("2022-05-04 00:00:00.123", "2022-05-04 00:00:00.123 UTC"),
+            ("2022-05-04 00:00:00.123 UTC", "2022-05-04 00:00:00.123 UTC"),
+            (
+                "2022-05-04 00:00:00.123456 UTC",
+                "2022-05-04 00:00:00.123456 UTC",
+            ),
+        ] {
+            assert_eq!(
+                dune_date(date_str).unwrap().to_string(),
+                expected,
+                "failed for {date_str}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## What & why

Dune returns numeric columns as JSON numbers or strings depending on the column type, but `f64_from_str` only accepted strings — it errored on actual JSON numbers, forcing consumers to hand-roll `serde_json::Value`-based parsers (see duneanalytics/echo#4333 for a real example). This makes the helpers cover both wire representations so typed row structs work with just serde attributes:

- `f64_from_str` now accepts a JSON number or a numeric string.
- New `u64_from_str` counterpart for integer columns (bigints often arrive as strings).
- `datetime_from_str` additionally accepts RFC 3339 with any offset and the trailing ` UTC` suffix seen in query-result timestamps; `optional_datetime_from_str` now shares the same format chain instead of only the API metadata format.

README and rustdoc examples updated to show a fully-typed row struct using the helpers, including the optional-datetime case.